### PR TITLE
SAP-360-BK-Reset-password-email-template-japanese-stage-one

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -115,6 +115,7 @@ TEMPLATES = [
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [
             os.path.join(PROJECT_DIR, "templates"),
+            os.path.join(BASE_DIR, "users/templates"),
         ],
         "APP_DIRS": True,
         "OPTIONS": {

--- a/users/templates/account/email/base_message.txt
+++ b/users/templates/account/email/base_message.txt
@@ -1,0 +1,7 @@
+{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name %}Hi from {{ site_name }}!{% endblocktrans %}
+
+{% block content %}{% endblock %}
+
+{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you for using {{ site_name }}!
+{{ site_domain }}{% endblocktrans %}
+{% endautoescape %}

--- a/users/templates/account/email/password_reset_key_message.txt
+++ b/users/templates/account/email/password_reset_key_message.txt
@@ -1,0 +1,9 @@
+{% extends "account/email/base_message.txt" %}
+{% load i18n %}
+
+{% block content %}{% autoescape off %}{% blocktrans %}Hey, you are receiving this e-mail because you or someone else has requested a password for your user account.
+It can be safely ignored if you did not request a password reset. Click the link below to reset your password.{% endblocktrans %}
+
+{{ password_reset_url }}{% if username %}
+
+{% blocktrans %}In case you forgot, your username is {{ username }}.{% endblocktrans %}{% endif %}{% endautoescape %}{% endblock %}

--- a/users/templates/account/email/password_reset_key_subject.txt
+++ b/users/templates/account/email/password_reset_key_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Yo - Password Reset E-mail{% endblocktrans %}
+{% endautoescape %}


### PR DESCRIPTION
Create alternative templates for allauth and djrest auth emails. Set up necessary mails for the reset email. 